### PR TITLE
Replace `config` global declaration with pre-definition

### DIFF
--- a/Main.py
+++ b/Main.py
@@ -22,14 +22,13 @@ global startTime
 startTime = time.time()
 client.remove_command('help')
 homedir = os.getcwd()
+config:dict = {}
 
 if os.name == 'nt':
     with open(f'{homedir}\\config.json', 'r') as f:
-        global config
         config = json.load(f)
 else:
     with open(f'{homedir}/config.json', 'r') as f:
-        global config
         config = json.load(f)
 
 snipe_log:bool = config[str("config")][str("logs")]["snipe"]


### PR DESCRIPTION
Using a global declaration for `config` could lead to SyntaxError being thrown in stdout on execution. This patch should fix SyntaxError from being thrown by using a pre-definition instead.