### PR TITLE
Add support for Discord Slash Commands

### DIFF
--- a/.idea/.gitignore
+++ b/.idea/.gitignore
@@ -1,0 +1,3 @@
+# Default ignored files
+/shelf/
+/workspace.xml

--- a/.idea/discord-snipe-bot.iml
+++ b/.idea/discord-snipe-bot.iml
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<module type="PYTHON_MODULE" version="4">
+  <component name="NewModuleRootManager">
+    <content url="file://$MODULE_DIR$" />
+    <orderEntry type="inheritedJdk" />
+    <orderEntry type="sourceFolder" forTests="false" />
+  </component>
+</module>

--- a/.idea/discord.xml
+++ b/.idea/discord.xml
@@ -1,0 +1,7 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project version="4">
+  <component name="DiscordProjectSettings">
+    <option name="show" value="PROJECT_FILES" />
+    <option name="description" value="" />
+  </component>
+</project>

--- a/.idea/inspectionProfiles/profiles_settings.xml
+++ b/.idea/inspectionProfiles/profiles_settings.xml
@@ -1,0 +1,6 @@
+<component name="InspectionProjectProfileManager">
+  <settings>
+    <option name="USE_PROJECT_PROFILE" value="false" />
+    <version value="1.0" />
+  </settings>
+</component>

--- a/.idea/misc.xml
+++ b/.idea/misc.xml
@@ -1,0 +1,4 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project version="4">
+  <component name="ProjectRootManager" version="2" project-jdk-name="Python 3.10" project-jdk-type="Python SDK" />
+</project>

--- a/.idea/modules.xml
+++ b/.idea/modules.xml
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project version="4">
+  <component name="ProjectModuleManager">
+    <modules>
+      <module fileurl="file://$PROJECT_DIR$/.idea/discord-snipe-bot.iml" filepath="$PROJECT_DIR$/.idea/discord-snipe-bot.iml" />
+    </modules>
+  </component>
+</project>

--- a/.idea/vcs.xml
+++ b/.idea/vcs.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project version="4">
+  <component name="VcsDirectoryMappings">
+    <mapping directory="$PROJECT_DIR$" vcs="Git" />
+  </component>
+</project>

--- a/Main.py
+++ b/Main.py
@@ -1,5 +1,7 @@
 import os, time, os.path, discord, datetime, json
 from discord.ext import commands
+from discord_slash import SlashCommand, SlashContext
+from discord_slash.utils.manage_commands import create_choice, create_option
 from discord.ext.commands import *
 from discord.ext import tasks
 
@@ -18,6 +20,7 @@ if os.name == 'nt':
 else:
     os.system('clear')
 client = commands.Bot(command_prefix=str(prefix), intents=intents) ## READ COMMENT AT LINE 13 FOR MORE INFO ##
+slash = SlashCommand(client, sync_commands=True)
 global startTime
 startTime = time.time()
 client.remove_command('help')
@@ -102,6 +105,32 @@ async def editsnipe(ctx):
         em = discord.Embed(description=f'**Message before**:```{editsnipe_message_before_content[ctx.channel.id]}```\n**Message after**:```{editsnipe_message_after_content[ctx.channel.id]}```', color=randColor())
         em.set_footer(text=f'This message was edited by {editsnipe_message_author[channel.id]}')
         await ctx.send(embed = em)
+    except:
+        await ctx.reply(f'There are no recently edited messages in <#{ctx.channel.id}>')
+
+@slash.slash(
+    name="snipe",
+    description="Fetches the most-recently deleted message in this channel"
+)
+async def snipe(ctx:SlashContext):
+    channel = ctx.channel
+    try:
+        em = discord.Embed(name=f"Last deleted message in #{channel.name}", description=snipe_message_content[channel.id], color=randColor())
+        em.set_footer(text=f"This message was sent by {snipe_message_author[channel.id]}")
+        await ctx.send(embed=em)
+    except:
+        await ctx.send(f"There are no recently deleted messages in <#{channel.id}>")
+
+@slash.slash(
+    name="editsnipe",
+    description="Fetches the most-recently edited message in this channel"
+)
+async def editsnipe(ctx:SlashContext):
+    channel = ctx.channel
+    try:
+        em = discord.Embed(description=f'**Message before**:```{editsnipe_message_before_content[ctx.channel.id]}```\n**Message after**:```{editsnipe_message_after_content[ctx.channel.id]}```', color=randColor())
+        em.set_footer(text=f'This message was edited by {editsnipe_message_author[channel.id]}')
+        await ctx.send(embed=em)
     except:
         await ctx.reply(f'There are no recently edited messages in <#{ctx.channel.id}>')
 


### PR DESCRIPTION
### Discord Slash Commands
This has been added not only to make the bot nicer and more client-sided, we also added these to adjust to the new API restrictions set by discord, that all new bots should adopt the slash commands feature by the end of the month.