### PR TITLE
Resolve unexpected argument errors in discord embeds

### DIFF
--- a/Main.py
+++ b/Main.py
@@ -153,7 +153,7 @@ async def on_message_edit(message_before, message_after):
 async def snipe(ctx):
     channel = ctx.channel
     try:
-        em = discord.Embed(name=f"Last deleted message in #{channel.name}", description=snipe_message_content[channel.id], color=discord.Color.random())
+        em = discord.Embed(title=f"Last deleted message in #{channel.name}", description=snipe_message_content[channel.id], color=discord.Color.random())
         em.set_footer(text=f"This message was sent by {snipe_message_author[channel.id]}")
         await ctx.send(embed=em)
     except KeyError: await ctx.send(f"There are no recently deleted messages in <#{channel.id}>")
@@ -174,7 +174,7 @@ async def editsnipe(ctx):
 async def snipe(ctx: SlashContext):
     channel = ctx.channel
     try:
-        em = discord.Embed(name=f"Last deleted message in #{channel.name}", description=snipe_message_content[channel.id], color=discord.Color.random())
+        em = discord.Embed(title=f"Last deleted message in #{channel.name}", description=snipe_message_content[channel.id], color=discord.Color.random())
         em.set_footer(text=f"This message was sent by {snipe_message_author[channel.id]}")
         await ctx.send(embed=em)
     except KeyError: await ctx.send(f"There are no recently deleted messages in <#{channel.id}>")


### PR DESCRIPTION
"name" and "title" in `discord.Embed()` are *very* different.